### PR TITLE
Multi tag OR search

### DIFF
--- a/Sources/genie/main.swift
+++ b/Sources/genie/main.swift
@@ -172,12 +172,19 @@ func searchCommand() {
         // The second part of this if clause is because if the user passes the --json
         // flag, then CommandLine.argc is 4
         if CommandLine.argc >= 3 || (CommandLine.argc >= 4 && (jsonOutput || tagList)) {
-            let searchTag = CommandLine.arguments[2]
+            let searchTags: Array<String> = Array(CommandLine.arguments[2..<CommandLine.arguments.count])
             let genieTable = Table("genie")
             let host = Expression<String?>("host")
             let path = Expression<String?>("path")
             let tag = Expression<String>("tag")
-            let query = genieTable.select(path, host).filter(tag == searchTag)
+            let dupe = Expression<Bool>("cout", [Binding?])
+            // A query constructed as the following is for an inclusive OR of all tags
+            let query = genieTable.select(distinct: path, host).filter(searchTags.contains(tag))
+            // A query constructed as the following is for an AND of all tags
+            // select path, host from genie where tag in (searchTags) group by 1,2 having count(*) > (searchTags.count - 1);
+            //genieTable.group([Expressible], having: <#T##Expression<Bool>#>)
+            //let query = genieTable.group(path, host).filter(searchTags.contains(tag), having: )
+            // A query constructed as the following is the search for a single tag
             var outputArray: Dictionary<String, [Dictionary<String, String>]> = [:]
             var items: [Dictionary<String, String>] = []
 

--- a/Sources/genie/main.swift
+++ b/Sources/genie/main.swift
@@ -168,23 +168,15 @@ func removeCommand() {
 
 func searchCommand() {
     if checkDB() {
-        // TODO: This should be able to search for paths that match a set of tags
-        // The second part of this if clause is because if the user passes the --json
-        // flag, then CommandLine.argc is 4
+        // The second part of this if clause is because if the user passes either of
+        //the --json or --list flags, then CommandLine.argc is at least 4
         if CommandLine.argc >= 3 || (CommandLine.argc >= 4 && (jsonOutput || tagList)) {
             let searchTags: Array<String> = Array(CommandLine.arguments[2..<CommandLine.arguments.count])
             let genieTable = Table("genie")
             let host = Expression<String?>("host")
             let path = Expression<String?>("path")
             let tag = Expression<String>("tag")
-            let dupe = Expression<Bool>("cout", [Binding?])
-            // A query constructed as the following is for an inclusive OR of all tags
             let query = genieTable.select(distinct: path, host).filter(searchTags.contains(tag))
-            // A query constructed as the following is for an AND of all tags
-            // select path, host from genie where tag in (searchTags) group by 1,2 having count(*) > (searchTags.count - 1);
-            //genieTable.group([Expressible], having: <#T##Expression<Bool>#>)
-            //let query = genieTable.group(path, host).filter(searchTags.contains(tag), having: )
-            // A query constructed as the following is the search for a single tag
             var outputArray: Dictionary<String, [Dictionary<String, String>]> = [:]
             var items: [Dictionary<String, String>] = []
 

--- a/Sources/genie/main.swift
+++ b/Sources/genie/main.swift
@@ -49,7 +49,7 @@ func printUsage() {
         SUBCOMMANDS:
             help       Prints this help message
             rm         remove from the given PATH the given TAG
-            search (s) search for and return all PATHS that have TAG
+            search (s) search for and return all PATHS that have all of the given TAGs
             print  (p) show all tags applied to the given PATH
             tag    (t) tag the given PATH with the given TAG
         """

--- a/Sources/genie/main.swift
+++ b/Sources/genie/main.swift
@@ -171,7 +171,7 @@ func searchCommand() {
         // TODO: This should be able to search for paths that match a set of tags
         // The second part of this if clause is because if the user passes the --json
         // flag, then CommandLine.argc is 4
-        if CommandLine.argc == 3 || (CommandLine.argc == 4 && (jsonOutput || tagList)) {
+        if CommandLine.argc >= 3 || (CommandLine.argc >= 4 && (jsonOutput || tagList)) {
             let searchTag = CommandLine.arguments[2]
             let genieTable = Table("genie")
             let host = Expression<String?>("host")

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Use `genie --help` to see usage instructions
 | -- | -- | -- |
 | `help` | n/a | Prints this help message |
 | `rm [PATH] [TAG]` | n/a | remove from the given `PATH` the given `TAG` |
-| `search [TAG] [FLAG]` | `s` | search for and return all paths that have `TAG` |
+| `search [TAGLIST] [FLAG]` | `s` | search for and return all paths that have _all_ of the tags given in `TAGLIST` |
 | `print [PATH]` | `p` | show all tags applied to the given `PATH` |
 | `tag [PATH] [TAG] [FLAG]` | `t` | tag the given `PATH` with the given `TAG`, or print a list of all tags used. |
 


### PR DESCRIPTION
This fixes #9 , which allows users to now search for all file paths that match at least one of a given list of tags.